### PR TITLE
add formatting support to multi-line comments(comment-block)

### DIFF
--- a/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
@@ -1,0 +1,52 @@
+package net.revelc.code.formatter.xml.lib;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CommentFormatter {
+
+    private static final Pattern ORIGINAL_INDENT_PATTERN = Pattern.compile("^(?<indent>[\\s\\t]*)-->");
+
+    public String format(String tagText, String indent, String lineDelimiter, FormattingPreferences prefs) {
+        String[] lines = tagText.split(lineDelimiter);
+        String originalIndent = resolveOriginalIndent(lines);
+
+        List<String> newLines = new ArrayList<>();
+        for (String line : lines) {
+            newLines.add(indent + removeOriginalIndent(line, originalIndent));
+        }
+
+        return String.join(lineDelimiter, newLines);
+    }
+
+    private String resolveOriginalIndent(String[] lines) {
+        // only multi-line comments need replace original indentation.
+        if (lines.length < 2) {
+            return null;
+        }
+
+        for (int i = lines.length - 1; i >= 0; i--) {
+            String line = lines[i];
+
+            if (line.trim().endsWith("-->")) {
+                Matcher m = ORIGINAL_INDENT_PATTERN.matcher(line);
+                if (m.matches()) {
+                    return m.group("indent");
+                } else {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String removeOriginalIndent(String line, String indent) {
+        if (indent != null && line.startsWith(indent)) {
+            return line.substring(indent.length());
+        } else {
+            return line;
+        }
+    }
+}

--- a/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
@@ -77,6 +77,11 @@ public class XmlDocumentFormatter {
             indent(state.depth, indentBuilder);
             state.out.append(new XMLTagFormatter().format(tag.getTagText(), indentBuilder.toString(),
                     fDefaultLineDelimiter, prefs));
+        } else if (tag instanceof CommentReader) {
+            StringBuilder indentBuilder = new StringBuilder(30);
+            indent(state.depth, indentBuilder);
+            state.out.append(new CommentFormatter().format(tag.getTagText(), indentBuilder.toString(),
+                    fDefaultLineDelimiter, prefs));
         } else {
             state.out.append(tag.getTagText());
         }
@@ -174,6 +179,11 @@ public class XmlDocumentFormatter {
                 }
             }
             return node.toString();
+        }
+
+        @Override
+        public boolean requiresInitialIndent() {
+            return false;
         }
     }
 

--- a/src/test/resources/default-output.xml
+++ b/src/test/resources/default-output.xml
@@ -24,6 +24,19 @@ http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/sche
 
 	<!--Here's a comment surrounded wrapped by empty lines to make sure they are kept-->
 
+	<!--
+	Here's a comment block.
+	Make sure they have correct indentation after format.
+	-->
+
+	<!--
+	    Here's a comment block with leading spaces.
+	    Make sure they have correct indentation and keep the leading spaces after format.
+	-->
+
+	<!--Here's a comment block with unaligned block start/end.
+	    Make sure they have correct indentation after format.-->
+
 	<api-platform-gw:api apiName="${api-v2.name}" version="${api-v2.version}" flowRef="api-v2-main" create="true"
 		apikitRef="api-v2-config" doc:name="API Autodiscovery" />
 	<flow name="api-v2-main">

--- a/src/test/resources/multi-lined-attrs-output.xml
+++ b/src/test/resources/multi-lined-attrs-output.xml
@@ -47,6 +47,19 @@ http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/sche
 
 	<!--Here's a comment surrounded wrapped by empty lines to make sure they are kept-->
 
+	<!--
+	Here's a comment block.
+	Make sure they have correct indentation after format.
+	-->
+
+	<!--
+	    Here's a comment block with leading spaces.
+	    Make sure they have correct indentation and keep the leading spaces after format.
+	-->
+
+	<!--Here's a comment block with unaligned block start/end.
+	    Make sure they have correct indentation after format.-->
+
 	<api-platform-gw:api
 		apiName="${api-v2.name}"
 		version="${api-v2.version}"

--- a/src/test/resources/no-wrap-tags-output.xml
+++ b/src/test/resources/no-wrap-tags-output.xml
@@ -14,6 +14,19 @@ http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/sche
 
 	<!--Here's a comment surrounded wrapped by empty lines to make sure they are kept-->
 
+	<!--
+	Here's a comment block.
+	Make sure they have correct indentation after format.
+	-->
+
+	<!--
+	    Here's a comment block with leading spaces.
+	    Make sure they have correct indentation and keep the leading spaces after format.
+	-->
+
+	<!--Here's a comment block with unaligned block start/end.
+	    Make sure they have correct indentation after format.-->
+
 	<api-platform-gw:api apiName="${api-v2.name}" version="${api-v2.version}" flowRef="api-v2-main" create="true" apikitRef="api-v2-config" doc:name="API Autodiscovery" />
 	<flow name="api-v2-main">
 		<http:listener config-ref="api-httpsListenerConfig" path="/api/v2/*" doc:name="HTTP" />

--- a/src/test/resources/test-input.xml
+++ b/src/test/resources/test-input.xml
@@ -14,6 +14,19 @@ http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/sche
 
     <!--Here's a comment surrounded wrapped by empty lines to make sure they are kept-->
 
+    <!--
+    Here's a comment block.
+    Make sure they have correct indentation after format.
+    -->
+
+    <!--
+        Here's a comment block with leading spaces.
+        Make sure they have correct indentation and keep the leading spaces after format.
+    -->
+
+    <!--Here's a comment block with unaligned block start/end.
+    Make sure they have correct indentation after format.-->
+
     <api-platform-gw:api apiName="${api-v2.name}" version="${api-v2.version}" flowRef="api-v2-main" create="true" apikitRef="api-v2-config" doc:name="API Autodiscovery"/>
     <flow name="api-v2-main">
         <http:listener config-ref="api-httpsListenerConfig" path="/api/v2/*" doc:name="HTTP" />


### PR DESCRIPTION
Hi,

the purpose of this PR is to add formatting support to multi-line comments(eg. comment-block).

The current version only supports formatting single-line comments, resulting in inconsistent indentation when formatting multi-line comments. For example, when the indentation style is changed from two spaces to four spaces, the result will be something like this:

```xml
original(2 whitespaces):

  <!-- 
   | Slightly faster builds.
   | see https://issues.apache.org/jira/browse/MCOMPILER-209 
  -->

after format(4 whitespaces):

    <!-- 
   | Slightly faster builds.
   | see https://issues.apache.org/jira/browse/MCOMPILER-209 
  -->
```

I use the comment block end token(`-->`) to determine the original indentation of multi-line comments, and replace it with the new indentation line by line.
