### PR TITLE
[license] Add back the header portion for license to the test

### DIFF
--- a/src/test/java/net/revelc/code/formatter/xml/lib/FormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/xml/lib/FormatterTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Jose Montoya
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package net.revelc.code.formatter.xml.lib;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;


### PR DESCRIPTION
we need some form of this, not so sure on names of prior contributors here but mistakenly removed with fix to #49