### PR TITLE
Pr/47 Multiline comments fix

### DIFF
--- a/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
@@ -34,9 +34,8 @@ public class CommentFormatter {
                 Matcher m = ORIGINAL_INDENT_PATTERN.matcher(line);
                 if (m.matches()) {
                     return m.group("indent");
-                } else {
-                    return null;
                 }
+                return null;
             }
         }
         return null;
@@ -45,8 +44,7 @@ public class CommentFormatter {
     private static String removeOriginalIndent(String line, String indent) {
         if (indent != null && line.startsWith(indent)) {
             return line.substring(indent.length());
-        } else {
-            return line;
         }
+        return line;
     }
 }

--- a/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
@@ -9,7 +9,7 @@ public class CommentFormatter {
 
     private static final Pattern ORIGINAL_INDENT_PATTERN = Pattern.compile("^(?<indent>\\s*)-->");
 
-    public String format(String tagText, String indent, String lineDelimiter, FormattingPreferences prefs) {
+    public String format(String tagText, String indent, String lineDelimiter) {
         String[] lines = tagText.split(lineDelimiter);
         String originalIndent = resolveOriginalIndent(lines);
 

--- a/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
@@ -1,0 +1,52 @@
+package net.revelc.code.formatter.xml.lib;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CommentFormatter {
+
+    private static final Pattern ORIGINAL_INDENT_PATTERN = Pattern.compile("^(?<indent>[\\s\\t]*)-->");
+
+    public String format(String tagText, String indent, String lineDelimiter, FormattingPreferences prefs) {
+        String[] lines = tagText.split(lineDelimiter);
+        String originalIndent = resolveOriginalIndent(lines);
+
+        List<String> newLines = new ArrayList<>();
+        for (String line : lines) {
+            newLines.add(indent + removeOriginalIndent(line, originalIndent));
+        }
+
+        return String.join(lineDelimiter, newLines);
+    }
+
+    private String resolveOriginalIndent(String[] lines) {
+        // only multi-line comments need replace original indentation.
+        if (lines.length < 2) {
+            return null;
+        }
+
+        for (int i = lines.length - 1; i >= 0; i--) {
+            String line = lines[i];
+
+            if (line.trim().endsWith("-->")) {
+                Matcher m = ORIGINAL_INDENT_PATTERN.matcher(line);
+                if (m.matches()) {
+                    return m.group("indent");
+                } else {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String removeOriginalIndent(String line, String indent) {
+        if (indent != null && line.startsWith(indent)) {
+            return line.substring(indent.length());
+        } else {
+            return line;
+        }
+    }
+}

--- a/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/CommentFormatter.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 
 public class CommentFormatter {
 
-    private static final Pattern ORIGINAL_INDENT_PATTERN = Pattern.compile("^(?<indent>[\\s\\t]*)-->");
+    private static final Pattern ORIGINAL_INDENT_PATTERN = Pattern.compile("^(?<indent>\\s*)-->");
 
     public String format(String tagText, String indent, String lineDelimiter, FormattingPreferences prefs) {
         String[] lines = tagText.split(lineDelimiter);

--- a/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
@@ -85,8 +85,8 @@ public class XmlDocumentFormatter {
         } else if (tag instanceof CommentReader) {
             StringBuilder indentBuilder = new StringBuilder(30);
             indent(state.depth, indentBuilder);
-            state.out.append(new CommentFormatter().format(tag.getTagText(), indentBuilder.toString(),
-                    fDefaultLineDelimiter));
+            state.out.append(
+                    new CommentFormatter().format(tag.getTagText(), indentBuilder.toString(), fDefaultLineDelimiter));
         } else {
             String tagText = tag.getTagText();
             if (!prefs.getDeleteBlankLines()

--- a/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
@@ -82,6 +82,11 @@ public class XmlDocumentFormatter {
             indent(state.depth, indentBuilder);
             state.out.append(new XMLTagFormatter().format(tag.getTagText(), indentBuilder.toString(),
                     fDefaultLineDelimiter, prefs));
+        } else if (tag instanceof CommentReader) {
+            StringBuilder indentBuilder = new StringBuilder(30);
+            indent(state.depth, indentBuilder);
+            state.out.append(new CommentFormatter().format(tag.getTagText(), indentBuilder.toString(),
+                    fDefaultLineDelimiter, prefs));
         } else {
             String tagText = tag.getTagText();
             if (!prefs.getDeleteBlankLines()
@@ -183,6 +188,11 @@ public class XmlDocumentFormatter {
                 }
             }
             return node.toString();
+        }
+
+        @Override
+        public boolean requiresInitialIndent() {
+            return false;
         }
     }
 

--- a/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
@@ -86,7 +86,7 @@ public class XmlDocumentFormatter {
             StringBuilder indentBuilder = new StringBuilder(30);
             indent(state.depth, indentBuilder);
             state.out.append(new CommentFormatter().format(tag.getTagText(), indentBuilder.toString(),
-                    fDefaultLineDelimiter, prefs));
+                    fDefaultLineDelimiter));
         } else {
             String tagText = tag.getTagText();
             if (!prefs.getDeleteBlankLines()

--- a/src/test/java/net/revelc/code/formatter/xml/lib/FormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/xml/lib/FormatterTest.java
@@ -15,7 +15,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +31,11 @@ class FormatterTest {
 
         String inXml = Files.readString(Paths.get("src/test/resources/test-space-input.xml"));
         String outXml = formatter.format(inXml);
+
+        Path path = Paths.get("target/formatted/test-space-expected-result.xml");
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, outXml, StandardOpenOption.CREATE);
+
         assertEquals(outXml, Files.readString(Paths.get("src/test/resources/test-space-expected.xml")));
     }
 
@@ -38,6 +45,10 @@ class FormatterTest {
 
         String inXml = Files.readString(Paths.get("src/test/resources/test-input.xml"));
         String outXml = formatter.format(inXml);
+
+        Path path = Paths.get("target/formatted/default-output-result.xml");
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, outXml, StandardOpenOption.CREATE);
 
         assertEquals(outXml, Files.readString(Paths.get("src/test/resources/default-output.xml")));
     }
@@ -51,6 +62,10 @@ class FormatterTest {
         String inXml = Files.readString(Paths.get("src/test/resources/test-input.xml"));
         String outXml = formatter.format(inXml);
 
+        Path path = Paths.get("target/formatted/multi-lined-attrs-output-result.xml");
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, outXml, StandardOpenOption.CREATE);
+
         assertEquals(outXml, Files.readString(Paths.get("src/test/resources/multi-lined-attrs-output.xml")));
     }
 
@@ -62,6 +77,10 @@ class FormatterTest {
 
         String inXml = Files.readString(Paths.get("src/test/resources/test-input.xml"));
         String outXml = formatter.format(inXml);
+
+        Path path = Paths.get("target/formatted/no-wrap-tags-output-result.xml");
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, outXml, StandardOpenOption.CREATE);
 
         assertEquals(outXml, Files.readString(Paths.get("src/test/resources/no-wrap-tags-output.xml")));
     }

--- a/src/test/resources/default-output.xml
+++ b/src/test/resources/default-output.xml
@@ -24,6 +24,19 @@ http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/sche
 
 	<!--Here's a comment surrounded wrapped by empty lines to make sure they are kept-->
 
+	<!--
+	Here's a comment block.
+	Make sure they have correct indentation after format.
+	-->
+
+	<!--
+	    Here's a comment block with leading spaces.
+	    Make sure they have correct indentation and keep the leading spaces after format.
+	-->
+
+	<!--Here's a comment block with unaligned block start/end.
+	    Make sure they have correct indentation after format.-->
+
 	<api-platform-gw:api apiName="${api-v2.name}" version="${api-v2.version}" flowRef="api-v2-main" create="true"
 		apikitRef="api-v2-config" doc:name="API Autodiscovery" />
 	<flow name="api-v2-main">

--- a/src/test/resources/multi-lined-attrs-output.xml
+++ b/src/test/resources/multi-lined-attrs-output.xml
@@ -47,6 +47,19 @@ http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/sche
 
 	<!--Here's a comment surrounded wrapped by empty lines to make sure they are kept-->
 
+	<!--
+	Here's a comment block.
+	Make sure they have correct indentation after format.
+	-->
+
+	<!--
+	    Here's a comment block with leading spaces.
+	    Make sure they have correct indentation and keep the leading spaces after format.
+	-->
+
+	<!--Here's a comment block with unaligned block start/end.
+	    Make sure they have correct indentation after format.-->
+
 	<api-platform-gw:api
 		apiName="${api-v2.name}"
 		version="${api-v2.version}"

--- a/src/test/resources/no-wrap-tags-output.xml
+++ b/src/test/resources/no-wrap-tags-output.xml
@@ -14,6 +14,19 @@ http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/sche
 
 	<!--Here's a comment surrounded wrapped by empty lines to make sure they are kept-->
 
+	<!--
+	Here's a comment block.
+	Make sure they have correct indentation after format.
+	-->
+
+	<!--
+	    Here's a comment block with leading spaces.
+	    Make sure they have correct indentation and keep the leading spaces after format.
+	-->
+
+	<!--Here's a comment block with unaligned block start/end.
+	    Make sure they have correct indentation after format.-->
+
 	<api-platform-gw:api apiName="${api-v2.name}" version="${api-v2.version}" flowRef="api-v2-main" create="true" apikitRef="api-v2-config" doc:name="API Autodiscovery" />
 	<flow name="api-v2-main">
 		<http:listener config-ref="api-httpsListenerConfig" path="/api/v2/*" doc:name="HTTP" />

--- a/src/test/resources/test-input.xml
+++ b/src/test/resources/test-input.xml
@@ -14,6 +14,19 @@ http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/sche
 
     <!--Here's a comment surrounded wrapped by empty lines to make sure they are kept-->
 
+    <!--
+    Here's a comment block.
+    Make sure they have correct indentation after format.
+    -->
+
+    <!--
+        Here's a comment block with leading spaces.
+        Make sure they have correct indentation and keep the leading spaces after format.
+    -->
+
+    <!--Here's a comment block with unaligned block start/end.
+    Make sure they have correct indentation after format.-->
+
     <api-platform-gw:api apiName="${api-v2.name}" version="${api-v2.version}" flowRef="api-v2-main" create="true" apikitRef="api-v2-config" doc:name="API Autodiscovery"/>
     <flow name="api-v2-main">
         <http:listener config-ref="api-httpsListenerConfig" path="/api/v2/*" doc:name="HTTP" />


### PR DESCRIPTION
This replaces #47 fixing the issue.  I've additionally added new cycle on tests to print out the resulting files so when things are off they can easily be checked.  While original comments only discussed the set in format usage here, that was entirely irrelevant.  Seeing the output significantly helped there to understand the problem.  To check that I simply removed the comment patch call and then looked at results.  While I'm not certain that the non indentation should be moved further in part of the blocks, it seems as working as desired and clearly there was a defect.  I did remove the \\t as originally suggested as that is just a subset of \\s and therefore was entirely unnecessary.

One note: If there are blank lines in comments they will be retained even if the blank line deletion is selected at the moment.  I don't think that is a big deal but may need to be looked at down the road.