### PR TITLE
Use real logger slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     SPDX-License-Identifier: EPL-2.0
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>net.revelc.code</groupId>
@@ -49,4 +49,31 @@ SPDX-License-Identifier: EPL-2.0
     <!-- rat plugin is no good at validating EPL headers out of the box -->
     <rat.skip>true</rat.skip>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.36</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- ignore sfl4j-simple as required for testing -->
+            <ignore>org.slf4j:slf4j-simple</ignore>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ]
+}

--- a/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/lib/XmlDocumentFormatter.java
@@ -17,6 +17,8 @@ import java.util.stream.IntStream;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -24,6 +26,8 @@ import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 
 public class XmlDocumentFormatter {
+
+    private static final Logger logger = LoggerFactory.getLogger(XmlDocumentFormatter.class);
 
     private final String fDefaultLineDelimiter;
     private final FormattingPreferences prefs;
@@ -109,7 +113,8 @@ public class XmlDocumentFormatter {
             }
             reader.close();
         } catch (IOException e) {
-            System.out.println(e.getMessage());
+            logger.error("{}", e.getMessage());
+            logger.debug("", e);
         }
         return state.out.toString();
     }
@@ -129,12 +134,13 @@ public class XmlDocumentFormatter {
             XMLReader reader = parser.getXMLReader();
             reader.setErrorHandler(errorHandler);
             reader.parse(new InputSource(new StringReader(documentText)));
-        } catch (Exception exception) {
-            if (!(exception instanceof SAXParseException)
+        } catch (Exception e) {
+            if (!(e instanceof SAXParseException)
                     || !prefs.getWellFormedValidation().equals(FormattingPreferences.WARN)) {
-                throw new IllegalArgumentException(exception);
+                throw new IllegalArgumentException(e);
             }
-            System.err.println("WARN: " + exception.getMessage());
+            logger.error("WARN: {}", e.getMessage());
+            logger.debug("", e);
         }
     }
 


### PR DESCRIPTION
fixes #176 

Also has renovate file, ignore it.  That is for me, due to not agreeing, I'm using renovate and this is a small trade off.  Renovate is not on upstream but config file needed for me so I'm not fighting moving commit back and forth.